### PR TITLE
Add MVU chart search to library

### DIFF
--- a/src/main/java/com/github/idelstak/flopless/state/FloplessLoop.java
+++ b/src/main/java/com/github/idelstak/flopless/state/FloplessLoop.java
@@ -84,6 +84,9 @@ public final class FloplessLoop implements Source<History<FloplessState>>, Sink<
     private boolean transientAction(Action action) {
         return action instanceof Action.User.StartDrag
           || action instanceof Action.User.UpdatePreview
+          || action instanceof Action.User.LoadState
+          || action instanceof Action.User.LibrarySearchTerm
+          || action instanceof Action.User.ClearLibrarySearch
           || action instanceof Action.Effect;
     }
 }

--- a/src/main/java/com/github/idelstak/flopless/state/FloplessState.java
+++ b/src/main/java/com/github/idelstak/flopless/state/FloplessState.java
@@ -18,30 +18,35 @@ public record FloplessState(
   Optional<Coordinate> startCoordinate,
   SelectedRange previewRange,
   GridAction selectedAction,
-  SizingConfig sizingConfig) implements State {
+  SizingConfig sizingConfig,
+  String librarySearchTerm) implements State {
 
     public FloplessState selectRange(SelectedRange range) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, range, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, range, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     public FloplessState forTable(TableType tableType) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     public FloplessState forPosition(Position position) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     public FloplessState face(Facing facing) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     public FloplessState toggleLimpersSqueeze(boolean squeeze) {
-        return new FloplessState(tableType, position, facing, squeeze, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeeze, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     public FloplessState withSizing(SizingConfig sizing) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizing);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizing, librarySearchTerm);
+    }
+
+    public FloplessState withLibrarySearchTerm(String term) {
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, selectedAction, sizingConfig, term == null ? "" : term);
     }
 
     public BigDecimal raiseAmount() {
@@ -73,19 +78,19 @@ public record FloplessState(
     }
 
     FloplessState selectMode(SelectMode mode) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, mode, startCoordinate, previewRange, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, mode, startCoordinate, previewRange, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     FloplessState beginDrag(Optional<Coordinate> maybeCoordinate) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, maybeCoordinate, previewRange, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, maybeCoordinate, previewRange, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     FloplessState showPreview(SelectedRange range) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, range, selectedAction, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, range, selectedAction, sizingConfig, librarySearchTerm);
     }
 
     FloplessState selectAction(GridAction action) {
-        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, action, sizingConfig);
+        return new FloplessState(tableType, position, facing, squeezeLimpers, selectedRange, selectMode, startCoordinate, previewRange, action, sizingConfig, librarySearchTerm);
     }
 
     FloplessState raise(BigDecimal amount) {
@@ -99,7 +104,8 @@ public record FloplessState(
           startCoordinate,
           previewRange,
           selectedAction,
-          sizingConfig.withOpenSize(amount.doubleValue())
+          sizingConfig.withOpenSize(amount.doubleValue()),
+          librarySearchTerm
         );
     }
 
@@ -114,7 +120,8 @@ public record FloplessState(
           startCoordinate,
           previewRange,
           selectedAction,
-          sizingConfig.withMinOpenSize(amount.doubleValue())
+          sizingConfig.withMinOpenSize(amount.doubleValue()),
+          librarySearchTerm
         );
     }
 
@@ -129,7 +136,8 @@ public record FloplessState(
           startCoordinate,
           previewRange,
           selectedAction,
-          sizingConfig.withPerLimper(amount.doubleValue())
+          sizingConfig.withPerLimper(amount.doubleValue()),
+          librarySearchTerm
         );
     }
 
@@ -144,7 +152,8 @@ public record FloplessState(
           startCoordinate,
           previewRange,
           selectedAction,
-          sizingConfig.withMinPerLimper(amount.doubleValue())
+          sizingConfig.withMinPerLimper(amount.doubleValue()),
+          librarySearchTerm
         );
     }
 
@@ -159,7 +168,8 @@ public record FloplessState(
           startCoordinate,
           previewRange,
           selectedAction,
-          sizingConfig.withReraisedIpMultiplier(multiplier.doubleValue())
+          sizingConfig.withReraisedIpMultiplier(multiplier.doubleValue()),
+          librarySearchTerm
         );
     }
 
@@ -174,7 +184,8 @@ public record FloplessState(
           startCoordinate,
           previewRange,
           selectedAction,
-          sizingConfig.withReraisedOopMultiplier(multiplier.doubleValue())
+          sizingConfig.withReraisedOopMultiplier(multiplier.doubleValue()),
+          librarySearchTerm
         );
     }
 
@@ -189,7 +200,8 @@ public record FloplessState(
           startCoordinate,
           previewRange,
           selectedAction,
-          sizingConfig.withPremiumOverride(hand, amountBb.doubleValue())
+          sizingConfig.withPremiumOverride(hand, amountBb.doubleValue()),
+          librarySearchTerm
         );
     }
 
@@ -204,7 +216,8 @@ public record FloplessState(
           state.startCoordinate(),
           state.previewRange(),
           state.selectedAction(),
-          state.sizingConfig()
+          state.sizingConfig(),
+          state.librarySearchTerm()
         );
     }
 
@@ -219,7 +232,8 @@ public record FloplessState(
           Optional.empty(),
           SelectedRange.none(),
           new GridAction.Fold(),
-          SizingConfig.defaults()
+          SizingConfig.defaults(),
+          ""
         );
     }
 }

--- a/src/main/java/com/github/idelstak/flopless/state/ReducedState.java
+++ b/src/main/java/com/github/idelstak/flopless/state/ReducedState.java
@@ -71,7 +71,11 @@ public final class ReducedState implements Reduced<FloplessState, Action, Flople
             case Action.User.DeleteState a ->
                 delete(state, a);
             case Action.User.LoadState a ->
-                load(a);
+                load(state, a);
+            case Action.User.LibrarySearchTerm a ->
+                librarySearchTerm(state, a);
+            case Action.User.ClearLibrarySearch _ ->
+                clearLibrarySearch(state);
 
             default ->
                 state;
@@ -292,14 +296,26 @@ public final class ReducedState implements Reduced<FloplessState, Action, Flople
 
         var afterDelete = persistence.loadAll();
         if (afterDelete.isEmpty()) {
-            return FloplessState.initial();
+            return FloplessState.initial().withLibrarySearchTerm(current.librarySearchTerm());
         }
 
         var fallbackIndex = deletedIndex >= 0 ? Math.min(deletedIndex, afterDelete.size() - 1) : 0;
-        return FloplessState.initial().copy(afterDelete.get(fallbackIndex));
+        return FloplessState.initial()
+          .copy(afterDelete.get(fallbackIndex))
+          .withLibrarySearchTerm(current.librarySearchTerm());
     }
 
-    private FloplessState load(Action.User.LoadState load) {
-        return FloplessState.initial().copy(load.state());
+    private FloplessState load(FloplessState current, Action.User.LoadState load) {
+        return FloplessState.initial()
+          .copy(load.state())
+          .withLibrarySearchTerm(current.librarySearchTerm());
+    }
+
+    private FloplessState librarySearchTerm(FloplessState state, Action.User.LibrarySearchTerm search) {
+        return state.withLibrarySearchTerm(search.term());
+    }
+
+    private FloplessState clearLibrarySearch(FloplessState state) {
+        return state.withLibrarySearchTerm("");
     }
 }

--- a/src/main/java/com/github/idelstak/flopless/state/api/Action.java
+++ b/src/main/java/com/github/idelstak/flopless/state/api/Action.java
@@ -128,5 +128,13 @@ public sealed interface Action {
         record LoadState(FloplessState state) implements Action {
 
         }
+
+        record LibrarySearchTerm(String term) implements User {
+
+        }
+
+        record ClearLibrarySearch() implements User {
+
+        }
     }
 }

--- a/src/main/java/com/github/idelstak/flopless/view/LibraryView.java
+++ b/src/main/java/com/github/idelstak/flopless/view/LibraryView.java
@@ -23,11 +23,16 @@ public final class LibraryView implements Initializable {
     private final Strategy strategy;
     private DisposableObserver<History<FloplessState>> observe;
     private String activeStateName;
+    private String searchTerm;
     private final ObservableList<FloplessState> ranges = FXCollections.observableArrayList();
     @FXML
     private ListView<FloplessState> rangesListView;
     @FXML
     private Button newRangeButton;
+    @FXML
+    private TextField chartsSearchField;
+    @FXML
+    private StackPane clearSearchPane;
 
     public LibraryView(Stage stage, FloplessLoop loop, Persistence persistence) {
         this.persistence = persistence;
@@ -36,13 +41,16 @@ public final class LibraryView implements Initializable {
         strategy = new Strategy();
 
         activeStateName = "";
+        searchTerm = "";
     }
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         var savedStates = persistence.loadAll();
         setupListView();
-        Platform.runLater(() -> renderLibrary(savedStates));
+        Platform.runLater(() -> renderLibrary(savedStates, searchTerm));
+        clearSearchPane.setVisible(false);
+        clearSearchPane.setManaged(false);
         setupActions();
         setupSubscription();
 
@@ -124,16 +132,17 @@ public final class LibraryView implements Initializable {
         loop.accept(new Action.Effect.DeleteStateConfirmRequested(state));
     }
 
-    private void renderLibrary(List<FloplessState> states) {
+    private void renderLibrary(List<FloplessState> states, String searchTerm) {
+        var filtered = filterStates(states, searchTerm);
         int activeIndex = -1;
-        for (int i = 0; i < states.size(); i++) {
-            if (strategy.name(states.get(i)).equals(activeStateName)) {
+        for (int i = 0; i < filtered.size(); i++) {
+            if (strategy.name(filtered.get(i)).equals(activeStateName)) {
                 activeIndex = i;
                 break;
             }
         }
 
-        ranges.setAll(states);
+        ranges.setAll(filtered);
         rangesListView.refresh();
         if (activeIndex >= 0) {
             int indexToScroll = activeIndex;
@@ -144,6 +153,12 @@ public final class LibraryView implements Initializable {
     private void setupActions() {
         newRangeButton.setOnAction(_ ->
           loop.accept(new Action.User.LoadState(FloplessState.initial())));
+
+        chartsSearchField.textProperty().addListener((_, _, nextText) ->
+          loop.accept(new Action.User.LibrarySearchTerm(normalizeSearchTerm(nextText))));
+
+        clearSearchPane.setOnMouseClicked(_ ->
+          loop.accept(new Action.User.ClearLibrarySearch()));
     }
 
     private void setupSubscription() {
@@ -168,10 +183,33 @@ public final class LibraryView implements Initializable {
     }
 
     private void render(FloplessState state) {
-        var name = strategy.name(state);
-        activeStateName = name;
+        activeStateName = strategy.name(state);
+        searchTerm = normalizeSearchTerm(state.librarySearchTerm());
+
+        if (!searchTerm.equals(chartsSearchField.getText())) {
+            chartsSearchField.setText(searchTerm);
+        }
+
+        var hasSearch = !searchTerm.isBlank();
+        clearSearchPane.setVisible(hasSearch);
+        clearSearchPane.setManaged(hasSearch);
+
         var savedStates = persistence.loadAll();
-        renderLibrary(savedStates);
+        renderLibrary(savedStates, searchTerm);
+    }
+
+    private String normalizeSearchTerm(String text) {
+        return text == null ? "" : text;
+    }
+
+    private List<FloplessState> filterStates(List<FloplessState> states, String searchTerm) {
+        if (searchTerm.isBlank()) {
+            return states;
+        }
+        var query = searchTerm.trim().toLowerCase(Locale.ROOT);
+        return states.stream()
+          .filter(state -> strategy.name(state).toLowerCase(Locale.ROOT).contains(query))
+          .toList();
     }
 
     private void dispose() {

--- a/src/main/java/com/github/idelstak/flopless/view/ToolbarView.java
+++ b/src/main/java/com/github/idelstak/flopless/view/ToolbarView.java
@@ -90,6 +90,7 @@ public final class ToolbarView implements Initializable {
         clearGridButton.setDisable(state.selectedRange().coordinates().isEmpty());
         undoButton.setDisable(!history.canUndo());
         redoButton.setDisable(!history.canRedo());
+        saveButton.setDisable(!history.canUndo() && !history.canRedo());
     }
 
     private void dispose() {

--- a/src/main/resources/fxml/librarysidebar.fxml
+++ b/src/main/resources/fxml/librarysidebar.fxml
@@ -2,8 +2,10 @@
 
 <?import java.lang.*?>
 <?import java.net.*?>
+<?import javafx.scene.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import javafx.scene.shape.*?>
 <?import org.kordamp.ikonli.javafx.*?>
 
 <VBox xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.idelstak.flopless.view.LibraryView">
@@ -23,6 +25,28 @@
             <FontIcon />
          </graphic>
       </Button>
+      <StackPane styleClass="search-container">
+         <children>
+            <TextField fx:id="chartsSearchField" promptText="Search charts..." styleClass="search-input" />
+            <HBox alignment="CENTER_LEFT" mouseTransparent="true" pickOnBounds="false">
+               <children>
+                  <SVGPath content="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16z M21 21l-4.35-4.35" scaleX="0.6" scaleY="0.6" styleClass="search-icon" />
+               </children>
+            </HBox>
+            <HBox alignment="CENTER_RIGHT" layoutX="10.0" layoutY="10.0" pickOnBounds="false">
+               <children>
+                  <StackPane fx:id="clearSearchPane" styleClass="clear-search">
+                     <children>
+                        <SVGPath content="M18 6L6 18M6 6l12 12" scaleX="0.7" scaleY="0.7" styleClass="clear-icon" />
+                     </children>
+                     <cursor>
+                        <Cursor fx:constant="HAND" />
+                     </cursor>
+                  </StackPane>
+               </children>
+            </HBox>
+         </children>
+      </StackPane>
       <ListView fx:id="rangesListView" styleClass="library-list" VBox.vgrow="ALWAYS" />
    </children>
 </VBox>

--- a/src/main/resources/styles/grid.css
+++ b/src/main/resources/styles/grid.css
@@ -1,18 +1,18 @@
 .root-pane {
     -fx-background-color: -fx-grid-border;
     -fx-border-color: -fx-grid-border;
-    -fx-border-width: 0.0625em;
+    -fx-border-width: 1;
     -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.5), 10, 0, 0, 4);
-    -fx-pref-width: 700;
-    -fx-pref-height: 700;
-    -fx-padding: 0 2 0 1
+    -fx-pref-width: 705;
+    -fx-pref-height: 702;
+    -fx-padding: 2 2 2 1
 }
 .poker-grid {
     -fx-alignment: center;
     -fx-background-color: -fx-grid-border;
-    -fx-hgap: 1px;
-    -fx-vgap: 1px;
-    -fx-background-radius: 0.5em;
+    -fx-hgap: 2;
+    -fx-vgap: 2;
+    -fx-background-radius: 6;
     -fx-padding: 0
 }
 .cell {

--- a/src/main/resources/styles/main.css
+++ b/src/main/resources/styles/main.css
@@ -31,7 +31,7 @@
 
 .delete-modal-body {
     -fx-text-fill: derive(-fx-text-active, -30%);
-    -fx-font-size: 12px;
+    -fx-font-size: 14px;
     -fx-line-spacing: 2px
 }
 

--- a/src/main/resources/styles/sidebar.css
+++ b/src/main/resources/styles/sidebar.css
@@ -222,6 +222,7 @@
     -fx-background-color: transparent
 }
 .grid-item {
+    -fx-spacing: 2;
     -fx-background-color: -fx-card-bg;
     -fx-border-color: -fx-grid-border;
     -fx-border-radius: 8;
@@ -256,7 +257,7 @@
     -fx-border-color: transparent;
     -fx-background-radius: 6;
     -fx-border-radius: 6;
-    -fx-padding: 6;
+    -fx-padding: 3;
     -fx-cursor: hand;
     -fx-opacity: 0
 }
@@ -275,34 +276,6 @@
 }
 .delete-chart-btn:pressed {
     -fx-background-color: #450a0a
-}
-.delete-dialog {
-    -fx-background-color: -fx-sidebar-bg;
-    -fx-border-color: -fx-grid-border;
-    -fx-border-width: 1;
-    -fx-background-radius: 10;
-    -fx-border-radius: 10
-}
-.delete-dialog:header *.header-panel {
-    -fx-background-color: transparent;
-    -fx-padding: 16 16 0 16
-}
-.delete-dialog:header *.header-panel *.label {
-    -fx-text-fill: -fx-text-active;
-    -fx-font-size: 14px;
-    -fx-font-family: 'Geist SemiBold'
-}
-.delete-dialog > *.content.label {
-    -fx-text-fill: derive(-fx-text-active, -30%);
-    -fx-font-size: 12px;
-    -fx-padding: 8 16 16 16
-}
-.delete-dialog .button-bar .button {
-    -fx-font-family: 'Geist SemiBold';
-    -fx-background-radius: 6;
-    -fx-border-radius: 6;
-    -fx-padding: 8 14 8 14;
-    -fx-cursor: hand
 }
 .delete-cancel-btn {
     -fx-background-color: -fx-card-bg;

--- a/src/main/resources/styles/sidebar.css
+++ b/src/main/resources/styles/sidebar.css
@@ -7,7 +7,6 @@
     -fx-padding: 15 16 18 16
 }
 .sidebar.actions {
-    /*-fx-pref-width: 300;*/
     -fx-background-radius: 0 0 12 0;
     -fx-border-radius: 0 0 12 0;
     -fx-padding: 15 16 18 18
@@ -18,7 +17,7 @@
     -fx-border-radius: 0 0 0 12px;
     -fx-background-color: #0d0f12;
     -fx-border-color: #2a2e35 #2a2e35 transparent transparent;
-    -fx-padding: 20
+    -fx-padding: 12 18 18 18
 }
 .config-group {
     -fx-spacing: 12px
@@ -167,7 +166,7 @@
     -fx-alignment: center
 }
 .spinner-input.premium-hands {
-    -fx-pref-width: 40;
+    -fx-pref-width: 40
 }
 .spinner-suffix {
     -fx-text-fill: -fx-text-muted;
@@ -252,7 +251,6 @@
 .grid-item.active .label {
     -fx-text-fill: -fx-accent-primary
 }
-
 .delete-chart-btn {
     -fx-background-color: transparent;
     -fx-border-color: transparent;
@@ -260,32 +258,24 @@
     -fx-border-radius: 6;
     -fx-padding: 6;
     -fx-cursor: hand;
-    -fx-opacity: 0.0
+    -fx-opacity: 0
 }
-
 .delete-chart-icon {
     -fx-icon-size: 14;
     -fx-icon-color: derive(-fx-text-active, -45%)
 }
-
-.grid-item:hover .delete-chart-btn,
-.grid-item:focused .delete-chart-btn,
-.grid-item.active .delete-chart-btn {
-    -fx-opacity: 1.0
+.grid-item:hover .delete-chart-btn, .grid-item:focused .delete-chart-btn, .grid-item.active .delete-chart-btn {
+    -fx-opacity: 1
 }
-
 .delete-chart-btn:hover {
     -fx-background-color: -fx-remove-preview
 }
-
 .delete-chart-btn:hover .delete-chart-icon {
     -fx-icon-color: #fecaca
 }
-
 .delete-chart-btn:pressed {
     -fx-background-color: #450a0a
 }
-
 .delete-dialog {
     -fx-background-color: -fx-sidebar-bg;
     -fx-border-color: -fx-grid-border;
@@ -293,24 +283,20 @@
     -fx-background-radius: 10;
     -fx-border-radius: 10
 }
-
 .delete-dialog:header *.header-panel {
     -fx-background-color: transparent;
     -fx-padding: 16 16 0 16
 }
-
 .delete-dialog:header *.header-panel *.label {
     -fx-text-fill: -fx-text-active;
     -fx-font-size: 14px;
     -fx-font-family: 'Geist SemiBold'
 }
-
 .delete-dialog > *.content.label {
     -fx-text-fill: derive(-fx-text-active, -30%);
     -fx-font-size: 12px;
     -fx-padding: 8 16 16 16
 }
-
 .delete-dialog .button-bar .button {
     -fx-font-family: 'Geist SemiBold';
     -fx-background-radius: 6;
@@ -318,23 +304,67 @@
     -fx-padding: 8 14 8 14;
     -fx-cursor: hand
 }
-
 .delete-cancel-btn {
     -fx-background-color: -fx-card-bg;
     -fx-text-fill: -fx-text-active;
     -fx-border-color: -fx-grid-border
 }
-
 .delete-cancel-btn:hover {
     -fx-background-color: derive(-fx-card-bg, 6%)
 }
-
 .delete-confirm-btn {
     -fx-background-color: #7f1d1d;
     -fx-text-fill: #fee2e2;
     -fx-border-color: transparent
 }
-
 .delete-confirm-btn:hover {
     -fx-background-color: #991b1b
+}
+.search-container { }
+.search-input {
+    -fx-background-color: #16191d;
+    -fx-border-color: #2a2e35;
+    -fx-border-radius: 8px;
+    -fx-background-radius: 8px;
+    -fx-padding: 10px 34px 10px 34px;
+    -fx-font-size: 13px;
+    -fx-text-fill: white;
+    -fx-prompt-text-fill: #4b5563;
+    -fx-background-insets: 0;
+    -fx-focus-color: transparent;
+    -fx-faint-focus-color: transparent
+}
+.search-input:focused {
+    -fx-background-color: #1a1d21;
+    -fx-border-color: #10b981;
+    -fx-effect: dropshadow(three-pass-box, rgba(16, 185, 129, 0.1), 10, 0, 0, 0)
+}
+.search-icon {
+    -fx-fill: transparent;
+    -fx-stroke: #71767d;
+    -fx-stroke-width: 2.5;
+    -fx-translate-x: 12
+}
+.search-input:focused .search-icon {
+    -fx-stroke: #10b981
+}
+.clear-search {
+    -fx-background-radius: 50%;
+    -fx-translate-x: -12;
+    -fx-padding: 4;
+    -fx-max-width: 18;
+    -fx-max-height: 18;
+    -fx-min-width: 18;
+    -fx-min-height: 18
+}
+.clear-search:hover {
+    -fx-background-color: rgba(255, 255, 255, 0.1)
+}
+.clear-icon {
+    -fx-fill: transparent;
+    -fx-stroke: #71767d;
+    -fx-stroke-width: 2.5
+}
+.clear-search:hover .clear-icon {
+    -fx-stroke: white
 }

--- a/src/test/java/com/github/idelstak/flopless/state/ReducedStateTest.java
+++ b/src/test/java/com/github/idelstak/flopless/state/ReducedStateTest.java
@@ -244,6 +244,32 @@ final class ReducedStateTest {
     }
 
     @Test
+    void librarySearchTermSetsSearchTerm() {
+        var reduced = new ReducedState(new FakePersistence());
+        var before = FloplessState.initial();
+        var after = reduced.apply(before, new Action.User.LibrarySearchTerm("btn"));
+        assertThat(after.librarySearchTerm(), is("btn"));
+    }
+
+    @Test
+    void clearLibrarySearchResetsSearchTerm() {
+        var reduced = new ReducedState(new FakePersistence());
+        var before = FloplessState.initial().withLibrarySearchTerm("co");
+        var after = reduced.apply(before, new Action.User.ClearLibrarySearch());
+        assertThat(after.librarySearchTerm(), is(""));
+    }
+
+    @Test
+    void loadStatePreservesLibrarySearchTerm() {
+        var reduced = new ReducedState(new FakePersistence());
+        var current = FloplessState.initial().withLibrarySearchTerm("utg");
+        var toLoad = FloplessState.initial().forPosition(new Position.Btn());
+        var after = reduced.apply(current, new Action.User.LoadState(toLoad));
+        assertThat(after.position(), is(new Position.Btn()));
+        assertThat(after.librarySearchTerm(), is("utg"));
+    }
+
+    @Test
     void deleteStateRemovesSavedChartAndKeepsCurrentWhenDeletingAnotherChart() {
         var utg = FloplessState.initial().forPosition(new Position.Utg());
         var co = FloplessState.initial().forPosition(new Position.Co());


### PR DESCRIPTION
- Wire charts sidebar search into `Action`/`ReducedState`/`FloplessLoop`, persist search term in `FloplessState`, and filter `LibraryView` list from state.
- Hide clear search control when empty, preserve search term across load/delete flows, and add reducer tests for search set/clear/preserve behavior. Include related UI polish updates and toolbar save-button state refinement.